### PR TITLE
Battle Metrics Update

### DIFF
--- a/DiscordPlayerCountBot/Bot/Bot.cs
+++ b/DiscordPlayerCountBot/Bot/Bot.cs
@@ -19,16 +19,16 @@ namespace PlayerCountBot
         public BotInformation Information { get; set; }
         public DiscordSocketClient DiscordClient { get; set; }
         public Dictionary<int, IServerInformationProvider> DataProviders { get; set; } = new();
+        public Dictionary<string, string> ApplicationTokens { get; set; } = new();
 
         private ILog Logger = LogManager.GetLogger(typeof(Bot));
 
-        public Bot(BotInformation info)
+        public Bot(BotInformation info, Dictionary<string, string> applicationTokens)
         {
-            if (info is null)
-            {
-                throw new ArgumentNullException(nameof(info));
-            }
+            if (info is null) throw new ArgumentNullException(nameof(info));
+            if (applicationTokens is null) throw new ArgumentException(nameof(applicationTokens));
 
+            ApplicationTokens = applicationTokens;
             Information = info;
 
             DiscordClient = new DiscordSocketClient(new DiscordSocketConfig()
@@ -45,6 +45,7 @@ namespace PlayerCountBot
             DataProviders.Add((int)DataProvider.CFX, new CFXProvider());
             DataProviders.Add((int)DataProvider.SCUM, new ScumProvider());
             DataProviders.Add((int)DataProvider.MINECRAFT, new MinecraftProvider());
+            DataProviders.Add((int)DataProvider.BATTLEMETRICS, new BattleMetricsProvider());
         }
 
         public async Task StartAsync()
@@ -78,7 +79,7 @@ namespace PlayerCountBot
             }
 
             var dataProvider = DataProviders[dataProviderType];
-            var serverInformation = await dataProvider.GetServerInformation(Information);
+            var serverInformation = await dataProvider.GetServerInformation(Information, ApplicationTokens);
 
             if (serverInformation == null)
             {

--- a/DiscordPlayerCountBot/Bot/BotConfig.cs
+++ b/DiscordPlayerCountBot/Bot/BotConfig.cs
@@ -9,10 +9,10 @@ namespace PlayerCountBot
         public int UpdateTime { get; set; }
 
         [JsonProperty]
-        public string SteamAPIKey { get; set; }
+        public List<BotInformation> ServerInformation { get; set; } = new();
 
         [JsonProperty]
-        public List<BotInformation> ServerInformation { get; set; } = new();
+        public Dictionary<string, string> ApplicationTokens { get; set; } = new();
 
         public void CreateDefaults()
         {
@@ -26,7 +26,9 @@ namespace PlayerCountBot
                 UseNameAsLabel = false
             });
             UpdateTime = 30;
-            SteamAPIKey = "SteamAPIKeyHere";
+
+            ApplicationTokens.Add("SteamAPIKey", "");
+            ApplicationTokens.Add("BattleMetricsKey", "");
         }
     }
 }

--- a/DiscordPlayerCountBot/Bot/BotConfig.cs
+++ b/DiscordPlayerCountBot/Bot/BotConfig.cs
@@ -27,8 +27,8 @@ namespace PlayerCountBot
             });
             UpdateTime = 30;
 
-            ApplicationTokens.Add("SteamAPIKey", "");
-            ApplicationTokens.Add("BattleMetricsKey", "");
+            ApplicationTokens.Add("SteamAPIKey", "Here");
+            ApplicationTokens.Add("BattleMetricsKey", "Here");
         }
     }
 }

--- a/DiscordPlayerCountBot/Bot/BotInformation.cs
+++ b/DiscordPlayerCountBot/Bot/BotInformation.cs
@@ -28,14 +28,14 @@ namespace PlayerCountBot
         [JsonProperty]
         public ulong? ChannelID { get; set; }
 
-        [JsonIgnore]
-        public string SteamAPIToken { get; set; }
-
         public Tuple<string, ushort> GetAddressAndPort()
         {
             string[] splitData = Address.Split(":");
             try
             {
+                if (splitData.Length == 1)
+                    return new Tuple<string, ushort>(splitData[0], 0);
+
                 ushort port = ushort.Parse(splitData[1]);
                 return new Tuple<string, ushort>(splitData[0], port);
             }

--- a/DiscordPlayerCountBot/Configuration/DockerConfiguration.cs
+++ b/DiscordPlayerCountBot/Configuration/DockerConfiguration.cs
@@ -25,6 +25,7 @@ namespace DiscordPlayerCountBot.Configuration
             var botTags = Environment.GetEnvironmentVariable("BOT_USENAMETAGS")?.Split(";");
             var providerTypes = Environment.GetEnvironmentVariable("BOT_PROVIDERTYPES")?.Split(";");
 
+            var applicationTokens = Environment.GetEnvironmentVariable("BOT_APPLICATION_VARIABLES")?.Split(";").ToDictionary(data => data.Split(",")[0]) ?? new();
             var channelIDs = new List<ulong?>();
 
             if (Environment.GetEnvironmentVariables().Contains("BOT_CHANNELIDS"))
@@ -80,11 +81,10 @@ namespace DiscordPlayerCountBot.Configuration
                     Status = activity,
                     UseNameAsLabel = useNameAsLabel,
                     ChannelID = channelID ?? null,
-                    ProviderType = (int)EnumHelper.GetDataProvider(int.Parse(providerTypes?[i] ?? "0")),
-                    SteamAPIToken = Environment.GetEnvironmentVariable("STEAM_API_KEY") ?? "",
+                    ProviderType = (int)EnumHelper.GetDataProvider(int.Parse(providerTypes?[i] ?? "0"))
                 };
 
-                var bot = new Bot(info);
+                var bot = new Bot(info, applicationTokens);
                 await bot.StartAsync();
                 bots.Add(bot.Information.Address, bot);
             }

--- a/DiscordPlayerCountBot/Configuration/StandardConfiguration.cs
+++ b/DiscordPlayerCountBot/Configuration/StandardConfiguration.cs
@@ -38,8 +38,7 @@ namespace DiscordPlayerCountBot.Configuration
 
                 foreach (var info in config.ServerInformation)
                 {
-                    info.SteamAPIToken = config.SteamAPIKey;
-                    var bot = new Bot(info);
+                    var bot = new Bot(info, config.ApplicationTokens);
                     await bot.StartAsync();
                     bots.Add(bot.Information.Address, bot);
                 }

--- a/DiscordPlayerCountBot/Data/BattleMetrics/ServerListResponse.cs
+++ b/DiscordPlayerCountBot/Data/BattleMetrics/ServerListResponse.cs
@@ -1,0 +1,77 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace DiscordPlayerCountBot.Data
+{
+#nullable enable
+    public class BattleMetricsServerDetails
+    {
+        public List<string> modIds { get; set; } = new List<string>();
+        public List<string> modHashes { get; set; } = new List<string>();
+        public string? map { get; set; }
+        public string? time { get; set; }
+        public string? time_i { get; set; }
+        public bool? official { get; set; }
+        public string? gamemode { get; set; }
+        public List<string>? modNames { get; set; }
+        public bool? pve { get; set; }
+        public bool? modded { get; set; }
+        public bool? crossplay { get; set; }
+        public string? session_flags { get; set; }
+        public string? serverSteamId { get; set; }
+    }
+
+    public class BattleMetricsServerAttributes
+    {
+        public string? id { get; set; }
+        public string? name { get; set; }
+        public string? address { get; set; }
+        public string? ip { get; set; }
+        public int? port { get; set; }
+        public int? players { get; set; }
+        public int? maxPlayers { get; set; }
+        public int? rank { get; set; }
+        public List<double> location { get; set; } = new List<double>();
+        public string? status { get; set; }
+        public BattleMetricsServerDetails? details { get; set; }
+        public bool? @private { get; set; }
+        public DateTime? createdAt { get; set; }
+        public DateTime? updatedAt { get; set; }
+        public int? portQuery { get; set; }
+        public string? country { get; set; }
+        public string? queryStatus { get; set; }
+    }
+
+    public class BattleMetricsServerData
+    {
+        public string? type { get; set; }
+        public string? id { get; set; }
+        public BattleMetricsServerAttributes? attributes { get; set; }
+        public BattleMetricsServerRelationships? relationships { get; set; }
+    }
+
+    public class BattleMetricsServerGame
+    {
+        public BattleMetricsServerData? data { get; set; }
+    }
+
+    public class BattleMetricsServerRelationships
+    {
+        public BattleMetricsServerGame? game { get; set; }
+    }
+
+    public class Links
+    {
+        public string? prev { get; set; }
+        public string? next { get; set; }
+    }
+
+    public class BattleMetricsServerRoot
+    {
+        public List<BattleMetricsServerData>? data { get; set; }
+        public Links? links { get; set; }
+        public List<object>? included { get; set; }
+    }
+
+#nullable disable
+}

--- a/DiscordPlayerCountBot/Data/Steam/SteamServerListResponse.cs
+++ b/DiscordPlayerCountBot/Data/Steam/SteamServerListResponse.cs
@@ -12,7 +12,7 @@ namespace PlayerCountBot
             response = new SteamServerListSubClass();
         }
 
-        public SteamApiResponseData? GetServerDataByPort(string port)
+        public SteamApiResponseData? GetServerDataByPort(int port)
         {
             return response.GetAddressDataByPort(port);
         }

--- a/DiscordPlayerCountBot/Data/Steam/SteamServerListSubClass.cs
+++ b/DiscordPlayerCountBot/Data/Steam/SteamServerListSubClass.cs
@@ -13,11 +13,11 @@ namespace PlayerCountBot
             servers = new List<SteamApiResponseData>();
         }
 
-        public SteamApiResponseData? GetAddressDataByPort(string port)
+        public SteamApiResponseData? GetAddressDataByPort(int port)
         {
             foreach (SteamApiResponseData data in servers)
             {
-                if (data.addr.Split(":")[1] == port)
+                if (int.Parse(data.addr.Split(":")[1]) == port)
                 {
                     return data;
                 }

--- a/DiscordPlayerCountBot/Enum/DataProvider.cs
+++ b/DiscordPlayerCountBot/Enum/DataProvider.cs
@@ -5,6 +5,7 @@
         STEAM,
         CFX,
         SCUM,
-        MINECRAFT
+        MINECRAFT,
+        BATTLEMETRICS
     }
 }

--- a/DiscordPlayerCountBot/Http/HttpExecuter.cs
+++ b/DiscordPlayerCountBot/Http/HttpExecuter.cs
@@ -23,32 +23,32 @@ namespace DiscordPlayerCountBot.Http
             GC.SuppressFinalize(this);
         }
 
-        public async Task<TResponse?> GET<TRequest, TResponse>(string endPoint, IQueryParameterBuilder? queryBuilder = null, TRequest? body = default)
+        public async Task<TResponse?> GET<TRequest, TResponse>(string endPoint, IQueryParameterBuilder? queryBuilder = null, TRequest? body = default, Tuple<string, string>? authToken = null)
         {
-            return await ExecuteHttpRequest<TRequest, TResponse>(endPoint, HttpMethod.Get, queryBuilder, body);
+            return await ExecuteHttpRequest<TRequest, TResponse>(endPoint, HttpMethod.Get, queryBuilder, body, authToken);
         }
 
-        public async Task<TResponse?> POST<TRequest, TResponse>(string endPoint, IQueryParameterBuilder? queryBuilder = null, TRequest? body = default)
+        public async Task<TResponse?> POST<TRequest, TResponse>(string endPoint, IQueryParameterBuilder? queryBuilder = null, TRequest? body = default, Tuple<string, string>? authToken = null)
         {
-            return await ExecuteHttpRequest<TRequest, TResponse>(endPoint, HttpMethod.Post, queryBuilder, body);
+            return await ExecuteHttpRequest<TRequest, TResponse>(endPoint, HttpMethod.Post, queryBuilder, body, authToken);
         }
 
-        public async Task<TResponse?> PATCH<TRequest, TResponse>(string endPoint, IQueryParameterBuilder? queryBuilder = null, TRequest? body = default)
+        public async Task<TResponse?> PATCH<TRequest, TResponse>(string endPoint, IQueryParameterBuilder? queryBuilder = null, TRequest? body = default, Tuple<string, string>? authToken = null)
         {
-            return await ExecuteHttpRequest<TRequest, TResponse>(endPoint, HttpMethod.Patch, queryBuilder, body);
+            return await ExecuteHttpRequest<TRequest, TResponse>(endPoint, HttpMethod.Patch, queryBuilder, body, authToken);
         }
 
-        public async Task<TResponse?> PUT<TRequest, TResponse>(string endPoint, IQueryParameterBuilder? queryBuilder = null, TRequest? body = default)
+        public async Task<TResponse?> PUT<TRequest, TResponse>(string endPoint, IQueryParameterBuilder? queryBuilder = null, TRequest? body = default, Tuple<string, string>? authToken = null)
         {
-            return await ExecuteHttpRequest<TRequest, TResponse>(endPoint, HttpMethod.Put, queryBuilder, body);
+            return await ExecuteHttpRequest<TRequest, TResponse>(endPoint, HttpMethod.Put, queryBuilder, body, authToken);
         }
 
-        public async Task<TResponse?> DELETE<TRequest, TResponse>(string endPoint, IQueryParameterBuilder? queryBuilder = null, TRequest? body = default)
+        public async Task<TResponse?> DELETE<TRequest, TResponse>(string endPoint, IQueryParameterBuilder? queryBuilder = null, TRequest? body = default, Tuple<string, string>? authToken = null)
         {
-            return await ExecuteHttpRequest<TRequest, TResponse>(endPoint, HttpMethod.Delete, queryBuilder, body);
+            return await ExecuteHttpRequest<TRequest, TResponse>(endPoint, HttpMethod.Delete, queryBuilder, body, authToken);
         }
 
-        private async Task<TResponse?> ExecuteHttpRequest<TRequest, TResponse>(string endPoint, HttpMethod method, IQueryParameterBuilder? queryBuilder = null, TRequest? body = default)
+        private async Task<TResponse?> ExecuteHttpRequest<TRequest, TResponse>(string endPoint, HttpMethod method, IQueryParameterBuilder? queryBuilder = null, TRequest? body = default, Tuple<string, string>? authToken = null)
         {
             if (HttpClient == null) return default;
 
@@ -56,6 +56,9 @@ namespace DiscordPlayerCountBot.Http
             var fullPath = $"{endPoint}{queryParams}";
 
             using var request = new HttpRequestMessage(method, fullPath);
+
+            if (authToken != null)
+                request.Headers.Add(authToken?.Item1!, authToken?.Item2);
 
             if (body != null)
                 request.Content = new StringContent(JsonConvert.SerializeObject(body), Encoding.UTF8, "application/json");

--- a/DiscordPlayerCountBot/Http/IHttpExecuter.cs
+++ b/DiscordPlayerCountBot/Http/IHttpExecuter.cs
@@ -1,13 +1,14 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
 
 namespace DiscordPlayerCountBot.Http
 {
     public interface IHttpExecuter
     {
-        Task<TResponse?> DELETE<TRequest, TResponse>(string endPoint, IQueryParameterBuilder queryBuilder, TRequest? body);
-        Task<TResponse?> GET<TRequest, TResponse>(string endPoint, IQueryParameterBuilder queryBuilder, TRequest? body);
-        Task<TResponse?> PATCH<TRequest, TResponse>(string endPoint, IQueryParameterBuilder queryBuilder, TRequest? body);
-        Task<TResponse?> POST<TRequest, TResponse>(string endPoint, IQueryParameterBuilder queryBuilder, TRequest? body);
-        Task<TResponse?> PUT<TRequest, TResponse>(string endPoint, IQueryParameterBuilder queryBuilder, TRequest? body);
+        Task<TResponse?> DELETE<TRequest, TResponse>(string endPoint, IQueryParameterBuilder queryBuilder, TRequest? body, Tuple<string, string>? authToken = null);
+        Task<TResponse?> GET<TRequest, TResponse>(string endPoint, IQueryParameterBuilder queryBuilder, TRequest? body, Tuple<string, string>? authToken = null);
+        Task<TResponse?> PATCH<TRequest, TResponse>(string endPoint, IQueryParameterBuilder queryBuilder, TRequest? body, Tuple<string, string>? authToken = null);
+        Task<TResponse?> POST<TRequest, TResponse>(string endPoint, IQueryParameterBuilder queryBuilder, TRequest? body, Tuple<string, string>? authToken = null);
+        Task<TResponse?> PUT<TRequest, TResponse>(string endPoint, IQueryParameterBuilder queryBuilder, TRequest? body, Tuple<string, string>? authToken = null);
     }
 }

--- a/DiscordPlayerCountBot/Http/QueryParams/Base/BattleMetricsParameters.cs
+++ b/DiscordPlayerCountBot/Http/QueryParams/Base/BattleMetricsParameters.cs
@@ -1,0 +1,41 @@
+﻿using DiscordPlayerCountBot.Attributes;
+using System;
+using System.Linq;
+
+namespace DiscordPlayerCountBot.Http
+{
+
+    public class BattleMetricsParameters : QueryParameterBuilder
+    {
+        public override string CreateQueryParameterString()
+        {
+            var filterString = "";
+            var type = GetType();
+
+            int i = 0;
+            type.GetProperties().ToList().ForEach(property =>
+            {
+                var propertyValue = property.GetValue(this);
+
+                if (propertyValue != null)
+                {
+                    if (Attribute.GetCustomAttribute(property, typeof(NameAttribute)) is not NameAttribute nameAttribute)
+                    {
+                        throw new Exception("TODO: Throw actual error, not generic exception. Due to coding standards, we need attributes on parameters.");
+                    }
+
+                    if (i == 0)
+                        filterString += "?";
+
+                    if (i > 0)
+                        filterString += "&";
+
+                    filterString += $"filter[{nameAttribute.Name}]={propertyValue}";
+                    i++;
+                }
+            });
+
+            return filterString;
+        }
+    }
+}

--- a/DiscordPlayerCountBot/Http/QueryParams/Base/QueryParameterBuilder.cs
+++ b/DiscordPlayerCountBot/Http/QueryParams/Base/QueryParameterBuilder.cs
@@ -5,7 +5,7 @@ namespace DiscordPlayerCountBot.Http
 {
     public class QueryParameterBuilder : IQueryParameterBuilder
     {
-        public string CreateQueryParameterString()
+        public virtual string CreateQueryParameterString()
         {
             var type = GetType();
             var properties = type.GetProperties();

--- a/DiscordPlayerCountBot/Providers/Base/IServerInformationProvider.cs
+++ b/DiscordPlayerCountBot/Providers/Base/IServerInformationProvider.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using PlayerCountBot;
 
@@ -8,6 +9,6 @@ namespace DiscordPlayerCountBot.Providers.Base
     {
         bool WasLastExecutionAFailure { get; set; }
         Exception? LastException { get; set; }
-        Task<GenericServerInformation?> GetServerInformation(BotInformation information);
+        Task<GenericServerInformation?> GetServerInformation(BotInformation information, Dictionary<string, string> applicationVariables);
     }
 }

--- a/DiscordPlayerCountBot/Providers/Base/ServerInformationProvider.cs
+++ b/DiscordPlayerCountBot/Providers/Base/ServerInformationProvider.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using PlayerCountBot;
 
@@ -9,6 +10,6 @@ namespace DiscordPlayerCountBot.Providers.Base
         public bool WasLastExecutionAFailure { get; set; } = false;
         public Exception? LastException { get; set; }
 
-        public abstract Task<GenericServerInformation?> GetServerInformation(BotInformation information);
+        public abstract Task<GenericServerInformation?> GetServerInformation(BotInformation information, Dictionary<string, string> applicationVariables);
     }
 }

--- a/DiscordPlayerCountBot/Providers/MinecraftProvider.cs
+++ b/DiscordPlayerCountBot/Providers/MinecraftProvider.cs
@@ -6,13 +6,14 @@ using System;
 using System.Net.Http;
 using System.Net;
 using System.Threading.Tasks;
+using System.Collections.Generic;
 
 namespace DiscordPlayerCountBot.Providers
 {
     public class MinecraftProvider : ServerInformationProvider
     {
         private ILog Logger = LogManager.GetLogger(typeof(MinecraftProvider));
-        public async override Task<GenericServerInformation?> GetServerInformation(BotInformation information)
+        public async override Task<GenericServerInformation?> GetServerInformation(BotInformation information, Dictionary<string, string> applicationVariables)
         {
             var service = new MinecraftService();
             var addressAndPort = information.GetAddressAndPort();

--- a/DiscordPlayerCountBot/Providers/ScumProvider.cs
+++ b/DiscordPlayerCountBot/Providers/ScumProvider.cs
@@ -3,6 +3,7 @@ using DiscordPlayerCountBot.Services;
 using log4net;
 using PlayerCountBot;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
@@ -14,7 +15,7 @@ namespace DiscordPlayerCountBot.Providers
     {
         private ILog Logger = LogManager.GetLogger(typeof(ScumProvider));
 
-        public async override Task<GenericServerInformation?> GetServerInformation(BotInformation information)
+        public async override Task<GenericServerInformation?> GetServerInformation(BotInformation information, Dictionary<string, string> applicationVariables)
         {
             var service = new ScumService();
             var addressAndPort = information.GetAddressAndPort();

--- a/DiscordPlayerCountBot/Providers/SteamProvider.cs
+++ b/DiscordPlayerCountBot/Providers/SteamProvider.cs
@@ -3,6 +3,7 @@ using DiscordPlayerCountBot.Services;
 using log4net;
 using PlayerCountBot;
 using System;
+using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
@@ -13,14 +14,14 @@ namespace DiscordPlayerCountBot.Providers
     {
         private ILog Logger = LogManager.GetLogger(typeof(SteamProvider));
 
-        public async override Task<GenericServerInformation?> GetServerInformation(BotInformation information)
+        public async override Task<GenericServerInformation?> GetServerInformation(BotInformation information, Dictionary<string, string> applicationVariables)
         {
             var service = new SteamService();
-            var serverPortAndAddress = information.GetAddressAndPort();
 
             try
             {
-                var response = await service.GetSteamApiResponse(information);
+                var addressAndPort = information.GetAddressAndPort();
+                var response = await service.GetSteamApiResponse(addressAndPort.Item1, addressAndPort.Item2, applicationVariables["SteamAPIKey"]);
 
                 if (response == null)
                     throw new ApplicationException($"Server Address: {information.Address} was not found in Steam's directory.");
@@ -34,8 +35,8 @@ namespace DiscordPlayerCountBot.Providers
 
                 return new()
                 {
-                    Address = serverPortAndAddress.Item1,
-                    Port = serverPortAndAddress.Item2,
+                    Address = addressAndPort.Item1,
+                    Port = addressAndPort.Item2,
                     CurrentPlayers = response.players,
                     MaxPlayers = response.max_players,
                     PlayersInQueue = response.GetQueueCount()
@@ -48,6 +49,12 @@ namespace DiscordPlayerCountBot.Providers
 
                 WasLastExecutionAFailure = true;
                 LastException = e;
+
+                if (e is KeyNotFoundException keyNotFoundException)
+                {
+                    Logger.Error($"[SteamProvider] - SteamAPIKey is missing from Application variable configuration.");
+                    return null;
+                }
 
                 if (e is HttpRequestException requestException)
                 {

--- a/DiscordPlayerCountBot/Services/BattleMetricsService.cs
+++ b/DiscordPlayerCountBot/Services/BattleMetricsService.cs
@@ -1,0 +1,20 @@
+﻿using DiscordPlayerCountBot.Data;
+using DiscordPlayerCountBot.Http;
+using System;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace DiscordPlayerCountBot.Services
+{
+
+    public class BattleMetricsService : IBattleMetricsService
+    {
+        public async Task<BattleMetricsServerData?> GetPlayerInformationAsync(string address, string token)
+        {
+            using var httpClient = new HttpExecuter(new HttpClient());
+
+            var response = await httpClient.GET<object, BattleMetricsServerGame>($"https://api.battlemetrics.com/servers/{address}", authToken: new Tuple<string, string>("Authorization", token));
+            return response?.data;
+        }
+    }
+}

--- a/DiscordPlayerCountBot/Services/IBattleMetricsService.cs
+++ b/DiscordPlayerCountBot/Services/IBattleMetricsService.cs
@@ -1,0 +1,10 @@
+﻿using DiscordPlayerCountBot.Data;
+using System.Threading.Tasks;
+
+namespace DiscordPlayerCountBot.Services
+{
+    public interface IBattleMetricsService
+    {
+        public Task<BattleMetricsServerData?> GetPlayerInformationAsync(string address, string token);
+    }
+}

--- a/DiscordPlayerCountBot/Services/ISteamService.cs
+++ b/DiscordPlayerCountBot/Services/ISteamService.cs
@@ -5,6 +5,6 @@ namespace DiscordPlayerCountBot.Services
 {
     public interface ISteamService
     {
-        public Task<SteamApiResponseData?> GetSteamApiResponse(BotInformation information);
+        public Task<SteamApiResponseData?> GetSteamApiResponse(string address, int port, string token);
     }
 }

--- a/DiscordPlayerCountBot/Services/SteamService.cs
+++ b/DiscordPlayerCountBot/Services/SteamService.cs
@@ -11,19 +11,18 @@ namespace DiscordPlayerCountBot.Services
     {
         public ILog Logger = LogManager.GetLogger(typeof(SteamService));
 
-        public async Task<SteamApiResponseData?> GetSteamApiResponse(BotInformation information)
+        public async Task<SteamApiResponseData?> GetSteamApiResponse(string address, int port, string token)
         {
             using var httpClient = new HttpExecuter(new HttpClient());
             var response = await httpClient.GET<object, SteamServerListResponse>("https://api.steampowered.com/IGameServersService/GetServerList/v1/", new SteamGetServerListQueryParams()
             {
-                Key = information.SteamAPIToken,
-                Filter = $"\\addr\\{information.Address}"
+                Key = token,
+                Filter = $"\\addr\\{address}:{port}"
             });
 
             if (response == null) return null;
 
-            var serverPortAndAddress = information.GetAddressAndPort();
-            var data = response.GetServerDataByPort(serverPortAndAddress.Item2.ToString());
+            var data = response.GetServerDataByPort(port);
 
             if (data == null) return null;
 

--- a/DiscordPlayerCountBot/docker-compose.yml
+++ b/DiscordPlayerCountBot/docker-compose.yml
@@ -16,4 +16,4 @@ services:
        #Application Variables
        #These setting apply to the whole application.
        BOT_UPDATE_TIME: "30"
-       STEAM_API_KEY: "SteamAPIKeyHere"
+       BOT_APPLICATION_VARIABLES: "SteamAPIKey,KeyHere;BattleMetricsKey,KeyHere"

--- a/DiscordPlayerCountBot/docker-compose.yml
+++ b/DiscordPlayerCountBot/docker-compose.yml
@@ -16,4 +16,5 @@ services:
        #Application Variables
        #These setting apply to the whole application.
        BOT_UPDATE_TIME: "30"
+       #Keys and values are seperated by comas and each pair is seperated by a semi-colon.
        BOT_APPLICATION_VARIABLES: "SteamAPIKey,KeyHere;BattleMetricsKey,KeyHere"

--- a/README.MD
+++ b/README.MD
@@ -80,9 +80,9 @@ This bot works with many different providers to display your game server's playe
 | :----: | --- | --- | ---- |
 | Steam | 0 | Limit 1 Milion requests per 24 hours | Steam Query Port |
 | CFX | 1 | N/A | Game Port |
-| Scum | 2 | Uses game | Game Port |
-| Minecraft | 3 | NA | Game Port |
-| BattleMetrics | 4 | Uses Battle Metrics ID. [ID is the number in this URL](https://www.battlemetrics.com/servers/minecraft/5873087) | Battle Metrics Server ID |
+| Scum | 2 | N/A | Game Port |
+| Minecraft | 3 | N/A | Game Port |
+| BattleMetrics | 4 | Uses Battle Metrics ID. [ID is the number in this URL](https://www.battlemetrics.com/servers/minecraft/5873087) | N/A |
 
 #### Address Resolution
 You may use `localhost` or `hostname` as your server address for the application to automatically resolve the hosts IP.

--- a/README.MD
+++ b/README.MD
@@ -69,12 +69,13 @@ The available states that I have are as follows:
 This bot works with many different providers to display your game server's player counts. The available providers are listed below.
 
 
-| Name | Config Value |
-| :----: | --- |
-| Steam | 0 |
-| CFX | 1 |
-| Scum | 2 |
-| Minecraft | 3 |
+| Name | Config Value | Note |
+| :----: | --- | --- |
+| Steam | 0 | Limit 1 Milion requests per 24 hours |
+| CFX | 1 | N/A|
+| Scum | 2 | Uses game |
+| Minecraft | 3 | NA |
+| BattleMetrics | 4 | Uses Battle Metrics ID (Check the Battle Metrics URL on their website for your ID)| 
 
 #### Address Resolution
 You may use `localhost` or `hostname` as your server address for the application to automatically resolve the hosts IP.

--- a/README.MD
+++ b/README.MD
@@ -75,7 +75,7 @@ This bot works with many different providers to display your game server's playe
 | CFX | 1 | N/A|
 | Scum | 2 | Uses game |
 | Minecraft | 3 | NA |
-| BattleMetrics | 4 | Uses Battle Metrics ID (Check the Battle Metrics URL on their website for your ID)| 
+| BattleMetrics | 4 | Uses Battle Metrics ID (Check the Battle Metrics URL on their website for your ID) [Example](https://www.battlemetrics.com/servers/minecraft/5873087)| 
 
 #### Address Resolution
 You may use `localhost` or `hostname` as your server address for the application to automatically resolve the hosts IP.

--- a/README.MD
+++ b/README.MD
@@ -12,12 +12,17 @@ After installation of .Net Runtime 6, you need to run the application one time. 
 
 ![image](https://user-images.githubusercontent.com/24533882/188336821-4d368b36-ecfb-44a5-88f1-b05909f20b05.png)
 
-# Getting a Steam API key
-In order to get a steam API key, you will need a domain to link it to. Trying looking into [Google's domain site](https://domains.google.com/registrar/). After you have gotten a domain navigate to [Steam'd Web API Key Register](https://steamcommunity.com/dev/apikey), and get your Steam API Key. Copy your `Key` and put it in your config file by replacing `SteamAPIKeyHere` with your Steam API Key.
+# Getting a Steam API Key
+In order to get a Steam API key, you will need a domain to link it to. Trying looking into [Google's domain site](https://domains.google.com/registrar/). After you have gotten a domain navigate to [Steam'd Web API Key Register](https://steamcommunity.com/dev/apikey), and get your Steam API Key. Copy your `Key` and put it in your config file by replacing `SteamAPIKeyHere` with your Steam API Key.
 
 ![image](https://user-images.githubusercontent.com/24533882/103162963-c9304000-47b4-11eb-814e-c6156649b908.png)
 
-![image](https://user-images.githubusercontent.com/24533882/188337476-aa1919f1-4fa5-41e6-869d-9bb8827aa2e1.png)
+![image](https://user-images.githubusercontent.com/24533882/188550022-53db7967-ba8d-4100-b258-c81dc67514ca.png)
+
+# Getting a Battle Metrics Key
+In order to get a Battle Metrics API Key, you will need to visit [here](https://www.battlemetrics.com/developers), and generate an api token. After you must replace `Here` with your Battle Metrics API Key.
+
+![image](https://user-images.githubusercontent.com/24533882/188550180-070db933-0db9-45bd-bd17-caaf03ffc00c.png)
 
 
 # Creating a bot(s)
@@ -35,13 +40,15 @@ After you have created your bot and named it, you will need to copy the bots `To
 
 ![image](https://user-images.githubusercontent.com/24533882/103163390-9ab56380-47ba-11eb-9c44-ec7f83343078.png)
 
-![image](https://user-images.githubusercontent.com/24533882/188337485-ad4ecd6c-6c77-4ecb-bfe3-e5e107409624.png)
+![image](https://user-images.githubusercontent.com/24533882/188548745-78d978f5-652d-4a54-9fde-b490370ebc4f.png)
 
 
 # Configuring Server's
-After you have added your Steam API key, and your bot's token you must add the `botAddress`, this address is your query address for the server. This is so we know what game server's player count to display in the status of each bot. In order to configure the bot to display the player count, you must add the IP, and the Port in the format `Address:Port` ex. `23.23.233.233:27015` where `127.0.0.1:2532` is located. This address is **NOT** the connection address.
+After you have added your keyS, and your bot's token you must add the `botAddress`, this address is IP and port for the server. **Which port? That depends on your provider. Look [here.](#data-providers)**
 
-![image](https://user-images.githubusercontent.com/24533882/188337510-32d913b8-10a9-451c-9a90-18e26a10a054.png)
+If your data provider depends on a port, your address must be formatted as: `address:port`. Example: `127.0.0.1:3450`
+
+![image](https://user-images.githubusercontent.com/24533882/188548793-322db8f4-10d1-4963-9b88-16f9b7870b64.png)
 
 # Invite Your Bot
 After all configuration steps have been taken, we must start the bot and invite them into our discord. The bot needs no special permissions due to it's responsibility being to update it's status. In order to invite your discord bot, you must replace `{clientID}` with your bots client ID in the URL below, this means you must also remove the curly braces too. If you do not know where to obtain your bot's client ID, navigate to `General Information` tab on the Discord Developer Portal the bot you wish, and copy your Client ID from there.
@@ -62,25 +69,25 @@ The available states that I have are as follows:
 | Streaming | 1 | The user is streaming online |
 | Listening | 2 | The user is listening to a song. |
 | Watching | 3 | The user is watching some form of media. |
-| CustomStatus | 4 | The user has set a customer status. |
+| CustomStatus | 4 | The user has set a customer status. **Do not use.** |
 | Competing | 5 | The user is competing in a game. |
 
 #### Data Providers
 This bot works with many different providers to display your game server's player counts. The available providers are listed below.
 
 
-| Name | Config Value | Note |
-| :----: | --- | --- |
-| Steam | 0 | Limit 1 Milion requests per 24 hours |
-| CFX | 1 | N/A|
-| Scum | 2 | Uses game |
-| Minecraft | 3 | NA |
-| BattleMetrics | 4 | Uses Battle Metrics ID (Check the Battle Metrics URL on their website for your ID) [Example](https://www.battlemetrics.com/servers/minecraft/5873087)| 
+| Name | Config Value | Note | Port Type |
+| :----: | --- | --- | ---- |
+| Steam | 0 | Limit 1 Milion requests per 24 hours | Steam Query Port |
+| CFX | 1 | N/A | Game Port |
+| Scum | 2 | Uses game | Game Port |
+| Minecraft | 3 | NA | Game Port |
+| BattleMetrics | 4 | Uses Battle Metrics ID. [ID is the number in this URL](https://www.battlemetrics.com/servers/minecraft/5873087) | Battle Metrics Server ID |
 
 #### Address Resolution
 You may use `localhost` or `hostname` as your server address for the application to automatically resolve the hosts IP.
 
-![image](https://user-images.githubusercontent.com/24533882/188337540-6b57cd27-b307-476f-8bdf-e190d00ac2f5.png)
+![image](https://user-images.githubusercontent.com/24533882/188549477-753fb698-0d34-479b-970e-b2e265e90bd8.png)
 
 #### Channel Player Counts
 You may add the ChannelID variable to any bot to have the bot update the name of a text channel, or voice channel.
@@ -90,7 +97,7 @@ ChanelID does not need to be specified in either Docker, or Executable instances
 
 This rate limit is enforced by Discord, and not the library used Discord.Net
 
-![image](https://user-images.githubusercontent.com/24533882/188337578-ce80d5b3-1ff3-4cc4-aa38-86320f1a0459.png)
+![image](https://user-images.githubusercontent.com/24533882/188549536-35000ab2-5f90-416c-b641-29a534c9511f.png)
 
 **Voice Channel Format:**
 
@@ -110,7 +117,7 @@ This rate limit is enforced by Discord, and not the library used Discord.Net
 | Tag | Description |
 | :----: | --- |
 | latest | Latest stable releases |
-| Beta | May be unstable and contain unfinished features |
+| dev | May be unstable and contain unfinished features |
 
 ## Usage
 
@@ -135,7 +142,7 @@ There are two ways to deploy bots with Docker.
          BOT_STATUSES: "1;2"
          BOT_USENAMETAGS: "false;false"
          BOT_PROVIDERTYPES: "0;0"
-         STEAM_API_KEY: "your steam api key"
+         BOT_APPLICATION_VARIABLES: "SteamAPIKey,Here;BattleMetricsKey,Here"
   ```
  3. Edit variables and save the File
  4. Open terminal in a location of `docker-compose.yml` file and type `docker-compose up`
@@ -156,7 +163,7 @@ There are two ways to deploy bots with Docker.
     -e BOT_STATUSES='1;2' \
     -e BOT_PROVIDERTYPES='0;0' \
     -e BOT_USENAMETAGS='false;false' \
-    -e STEAM_API_KEY='your steam api key' \
+    -e BOT_APPLICATION_VARIABLES='SteamAPIKey,Here;BattleMetricsKey,Here' \
     specker/discordplayercountbot
   ```
  3. Edit values in single quotes and press enter
@@ -174,8 +181,8 @@ Container images are configured with help of those variables.
 | `BOT_STATUSES` | Discord Bots statuses |
 | `BOT_USENAMETAGS` | "TBD" |
 | `BOT_PROVIDERTYPES` | Who provides the data for the bot. |
-| `STEAM_API_KEY` | Steam Api Key |
 | `BOT_UPDATE_TIME` | How often bot should refresh |
+| `BOT_APPLICATION_VARIABLES` | Application Variables for all bots |
 
 To declare Multiple bots in docker separate values in `BOT_NAMES`, `BOT_PUBADDRESSES`, `BOT_PORTS`, `BOT_DISCORD_TOKENS`, `BOT_STATUSES`, `BOT_PROVIDERTYPES`, and `BOT_USENAMETAGS` with `;` 
  
@@ -187,6 +194,11 @@ To declare Multiple bots in docker separate values in `BOT_NAMES`, `BOT_PUBADDRE
   Two bots:
    `BOT_NAMES='Bot1;Bot2'`
 
+`BOT_APPLICATION_VARIABLES` is a key value pair. The key and value are seperated by commas, and each pair is seperated by a semi-colon.
+
+ Example:
+  `BOT_APPLICATION_VARIABLES='SteamAPIKey,34124124123rfwer1424124124;BattleMetricsKey,24124124124rwefwrgery5323423412312'`
+  
 # Issues
 Please report any issues to [Issues tab](https://github.com/GravityWolfNotAmused/PlayerCountDiscordBot/issues) or my discord.
 


### PR DESCRIPTION
# Support Battle Metrics as a Provider.

This update introduces Battle Metrics to the pool of available providers the bot can host for. This will allow others who use the Battle Metrics platform to expand their usage.

![GitHub release (latest by date)](https://img.shields.io/badge/BetaVersion-1.0.9-blue)

Documentation: [Here](https://github.com/GravityWolfNotAmused/PlayerCountDiscordBot/blob/battle-metrics-update/README.MD)