### PR TITLE
Implement channel name update rate limiting in Bot class

### DIFF
--- a/DiscordPlayerCountBot/Bot/Bot.cs
+++ b/DiscordPlayerCountBot/Bot/Bot.cs
@@ -14,6 +14,8 @@ public class Bot : LoggableClass
     public readonly Dictionary<DataProvider, IServerInformationProvider> DataProviders = [];
     public readonly Dictionary<string, string> ApplicationTokens = [];
     public string LastKnownStatus = string.Empty;
+    private DateTime _lastChannelNameUpdate = DateTime.MinValue;
+    private readonly TimeSpan _channelNameUpdateRateLimit = TimeSpan.FromMinutes(5);
 
     public Bot(BotInformation info, Dictionary<string, string> applicationTokens, Dictionary<DataProvider, IServerInformationProvider> dataProviders)
     {
@@ -134,6 +136,11 @@ public class Bot : LoggableClass
         LastKnownStatus = serverInformation.ReplaceTagsWithValues(Information.StatusFormat, Information.UseNameAsLabel, Information.Name);
 
         await DiscordClient.SetGameAsync(LastKnownStatus, null, (ActivityType)activityInteger);
-        await DiscordClient.SetChannelName(Information.ChannelID, LastKnownStatus);
+
+        if (DateTime.UtcNow - _lastChannelNameUpdate > _channelNameUpdateRateLimit)
+        {
+            await DiscordClient.SetChannelName(Information.ChannelID, LastKnownStatus);
+            _lastChannelNameUpdate = DateTime.UtcNow;
+        }
     }
 }

--- a/DiscordPlayerCountBot/EnvironmentParser/BotApplicationVariableParser.cs
+++ b/DiscordPlayerCountBot/EnvironmentParser/BotApplicationVariableParser.cs
@@ -1,4 +1,4 @@
-﻿using DiscordPlayerCountBot.EnvironmentParser.Base;
+using DiscordPlayerCountBot.EnvironmentParser.Base;
 
 namespace DiscordPlayerCountBot.EnvironmentParser;
 
@@ -7,8 +7,22 @@ public class BotApplicationVariableParser : EnvironmentParserBase<Dictionary<str
     public override string GetKey() => "BOT_APPLICATION_VARIABLES";
     public override Dictionary<string, string> ParseTyped(string? environmentVariable)
     {
-        return environmentVariable?.Split(";")
-            .Select(pair => pair.Split(','))
-            .ToDictionary(kv => kv[0], kv => kv[1]) ?? [];
+        if (string.IsNullOrEmpty(environmentVariable) || string.IsNullOrWhiteSpace(environmentVariable))
+            ArgumentException.ThrowIfNullOrEmpty(nameof(environmentVariable));
+
+        if (!environmentVariable!.Contains(';') && !environmentVariable.Contains(','))
+            throw new FormatException("The environment variable doesn't contain ';' and ','.");
+
+        if (!environmentVariable.Contains("SteamAPIKey", StringComparison.OrdinalIgnoreCase) && !environmentVariable.Contains("BattleMetricsKey", StringComparison.OrdinalIgnoreCase))
+            throw new FormatException("The input must contain either 'SteamAPIKey' or 'BattleMetricsKey'.");
+
+        if (!environmentVariable.Contains(','))
+            throw new FormatException("The environment variable must contain ','.");
+
+        return environmentVariable
+            .Split(';', StringSplitOptions.RemoveEmptyEntries)
+            .Select(pair => pair.Split(',', 2))
+            .Where(kv => kv.Length == 2)
+            .ToDictionary(kv => kv[0].Trim(), kv => kv[1].Trim());
     }
 }

--- a/DiscordPlayerCountBot/UpdateController.cs
+++ b/DiscordPlayerCountBot/UpdateController.cs
@@ -55,6 +55,20 @@ public class UpdateController : LoggableClass
         Time = config.Item2;
 
         Info($"Created: {Bots.Count} bot(s) that update every {Time} seconds.");
+        
+        // Check for channel IDs set with update frequency less than 5 minutes
+        if (Time < 300)
+        {
+            foreach (var bot in Bots.Values)
+            {
+                if (bot.Information.ChannelID != null && bot.Information.ChannelID != 0)
+                {
+                    Warn($"Bot '{bot.Information.Name}' has a channel ID set and update time is less than 5 minutes ({Time} seconds). " +
+                         $"Channel name updates will be rate-limited to once every 5 minutes regardless of update timer to avoid Discord API throttling.", 
+                         bot.Information.Id.ToString());
+                }
+            }
+        }
     }
 
     public async Task UpdatePlayerCounts()


### PR DESCRIPTION
This change allows people to specify an update value of less than 300 seconds, when having channel name updates enabled.

I found an issue that I wanted the bots to be as up to date as possible. But had to specify an Update Time greater than 300 seconds otherwise channel names went a bit crazy. 

Added a rather rudimentary check that validates whether then channel name update occurred greater than 5 minutes ago. 